### PR TITLE
feat: add floating "Torna su" button on post pages

### DIFF
--- a/app/components/BackToTop.css
+++ b/app/components/BackToTop.css
@@ -1,0 +1,79 @@
+.back-to-top {
+	position: fixed;
+	bottom: var(--sp-4);
+	right: var(--sp-4);
+	z-index: 900;
+	display: inline-flex;
+	align-items: center;
+	gap: var(--sp-2);
+	padding: var(--sp-2) var(--sp-3);
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--badge-text);
+	background-color: var(--primary);
+	border: none;
+	border-radius: 9999px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+	cursor: pointer;
+	transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.back-to-top:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 6px 16px rgba(0, 0, 0, 0.24);
+}
+
+.back-to-top:focus-visible {
+	outline: 2px solid var(--text-base-content);
+	outline-offset: 2px;
+}
+
+.back-to-top svg {
+	width: 1rem;
+	height: 1rem;
+}
+
+/* Enter/leave fade + slide. */
+.back-to-top-enter-active,
+.back-to-top-leave-active {
+	transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.back-to-top-enter-from,
+.back-to-top-leave-to {
+	opacity: 0;
+	transform: translateY(0.5rem);
+}
+
+@media (max-width: 480px) {
+	.back-to-top span {
+		/* Keep just the icon on narrow viewports to stay out of the way. */
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.back-to-top {
+		padding: var(--sp-3);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.back-to-top,
+	.back-to-top-enter-active,
+	.back-to-top-leave-active {
+		transition: none;
+	}
+
+	.back-to-top:hover {
+		transform: none;
+	}
+}

--- a/app/components/BackToTop.vue
+++ b/app/components/BackToTop.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from "vue";
+
+// Visible only once the page header (navigation) has scrolled out of view.
+const visible = ref(false);
+
+let observer: IntersectionObserver | null = null;
+const onScrollFallback = () => {
+	visible.value = window.scrollY > 200;
+};
+
+const scrollToTop = () => {
+	const prefersReducedMotion =
+		window.matchMedia &&
+		window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+	window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" });
+};
+
+onMounted(() => {
+	const header = document.querySelector(".header");
+
+	// Preferred: watch the header itself so the button mirrors the nav exactly.
+	if (header && "IntersectionObserver" in window) {
+		observer = new IntersectionObserver(
+			([entry]) => {
+				visible.value = !entry.isIntersecting;
+			},
+			{ threshold: 0 },
+		);
+		observer.observe(header);
+		return;
+	}
+
+	// Fallback for environments without IntersectionObserver.
+	window.addEventListener("scroll", onScrollFallback, { passive: true });
+	onScrollFallback();
+});
+
+onBeforeUnmount(() => {
+	if (observer) {
+		observer.disconnect();
+		observer = null;
+	}
+	window.removeEventListener("scroll", onScrollFallback);
+});
+</script>
+
+<template>
+  <Transition name="back-to-top">
+    <button
+      v-if="visible"
+      type="button"
+      class="back-to-top"
+      title="Torna su"
+      aria-label="Torna su"
+      @click="scrollToTop"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 19V5" />
+        <path d="m5 12 7-7 7 7" />
+      </svg>
+      <span>Torna su</span>
+    </button>
+  </Transition>
+</template>
+
+<style>
+@import './BackToTop.css';
+</style>

--- a/app/components/__tests__/BackToTop.test.ts
+++ b/app/components/__tests__/BackToTop.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import BackToTop from "../BackToTop.vue";
+
+describe("BackToTop", () => {
+	beforeEach(() => {
+		// Force the scroll fallback path: no header in the isolated mount and no
+		// IntersectionObserver available in the test environment.
+		// @ts-expect-error - removing for the fallback branch under test
+		delete window.IntersectionObserver;
+		window.scrollY = 0;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("is hidden while the page is at the top", () => {
+		const wrapper = mount(BackToTop);
+		expect(wrapper.find(".back-to-top").exists()).toBe(false);
+	});
+
+	it("appears once the page is scrolled down", async () => {
+		const wrapper = mount(BackToTop);
+
+		window.scrollY = 500;
+		window.dispatchEvent(new Event("scroll"));
+		await nextTick();
+
+		const button = wrapper.find(".back-to-top");
+		expect(button.exists()).toBe(true);
+		expect(button.attributes("aria-label")).toBe("Torna su");
+	});
+
+	it("scrolls back to the top when clicked", async () => {
+		const scrollTo = vi.fn();
+		window.scrollTo = scrollTo;
+
+		const wrapper = mount(BackToTop);
+		window.scrollY = 500;
+		window.dispatchEvent(new Event("scroll"));
+		await nextTick();
+
+		await wrapper.find(".back-to-top").trigger("click");
+		expect(scrollTo).toHaveBeenCalledWith(
+			expect.objectContaining({ top: 0 }),
+		);
+	});
+});

--- a/app/pages/post/[slug].vue
+++ b/app/pages/post/[slug].vue
@@ -53,6 +53,7 @@ const isReview = (tags: Array<string>): boolean => {
     <hr />
     <Sharing :url="post.path" />
     <Tip />
+    <BackToTop />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary

Adds a floating "Torna su" (back to top) button that appears **only on post pages**, becoming visible once the navigation header scrolls out of view.

## Details

- **`app/components/BackToTop.vue`** — uses an `IntersectionObserver` on the page `.header`, so the button appears exactly when the nav scrolls out of view (with a `scrollY > 200` scroll-position fallback for environments without `IntersectionObserver`). Clicking smoothly scrolls to the top, respecting `prefers-reduced-motion`. Observer/listener are cleaned up on unmount.
- **`app/components/BackToTop.css`** — sibling-CSS per repo convention, reusing existing design tokens (`--primary`, `--badge-text`, `--sp-*`). Fixed pill bottom-right with fade/slide transition, focus-visible outline, collapses to icon-only on narrow screens.
- **`app/pages/post/[slug].vue`** — mounts `<BackToTop />` here only, scoping it to post pages.
- **`app/components/__tests__/BackToTop.test.ts`** — covers hidden-at-top, appears-on-scroll, and scroll-to-top-on-click.

## Testing

All 74 tests pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqa9iTEqyU8h96MpyKjR8w)_