### PR TITLE
feat: adding "now" page

### DIFF
--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -26,6 +26,11 @@ const items: Array<NavItem> = [
 		href: "/tags",
 		title: "Articoli per tag",
 	},
+	{
+		name: "Adesso",
+		href: "/now",
+		title: "Cosa sto facendo in questo periodo",
+	},
 ];
 
 // const nav: Array<NavItem> = [EVENTS.earthDay, ...items];

--- a/app/components/__tests__/Event.server.test.ts
+++ b/app/components/__tests__/Event.server.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+const { event } = vi.hoisted(() => ({
+	event: {
+		name: "An Event",
+		url: "https://example.com/event",
+		date: "next month",
+	},
+}));
+
+vi.mock("@/utils/now", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/utils/now")>();
+	return {
+		...actual,
+		get NOW_EVENT() {
+			return event;
+		},
+	};
+});
+
+import Event from "../now/Event.server.vue";
+
+const stubs = {
+	NuxtLink: {
+		template: '<a :href="href"><slot /></a>',
+		props: ["href"],
+	},
+	IconsExternal: true,
+};
+
+describe("now/Event", () => {
+	it("renders correctly", () => {
+		const wrapper = mount(Event, { global: { stubs } });
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it("renders the event name linking to its url", () => {
+		const wrapper = mount(Event, { global: { stubs } });
+		const link = wrapper.find("a");
+		expect(link.attributes("href")).toBe(event.url);
+		expect(wrapper.text()).toContain(event.name);
+	});
+});

--- a/app/components/__tests__/Github.test.ts
+++ b/app/components/__tests__/Github.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const { getLatestRepos } = vi.hoisted(() => ({ getLatestRepos: vi.fn() }));
+
+vi.mock("@/utils/now", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/utils/now")>();
+	return { ...actual, getLatestRepos };
+});
+
+import Github from "../now/Github.vue";
+
+const stubs = {
+	NuxtLink: {
+		template: '<a :href="href"><slot /></a>',
+		props: ["href"],
+	},
+	IconsExternal: true,
+};
+
+describe("now/Github", () => {
+	beforeEach(() => {
+		getLatestRepos.mockReset();
+	});
+
+	it("shows a loading state before the data resolves", () => {
+		getLatestRepos.mockReturnValue(new Promise(() => {}));
+		const wrapper = mount(Github, { global: { stubs } });
+		expect(wrapper.text()).toContain("Caricamento");
+	});
+
+	it("renders the fetched repositories on success", async () => {
+		getLatestRepos.mockResolvedValue([
+			{
+				name: "repo-one",
+				url: "https://github.com/user/repo-one",
+				description: "First repo",
+				language: "TypeScript",
+				updatedAt: "2026-06-01T00:00:00Z",
+			},
+		]);
+		const wrapper = mount(Github, { global: { stubs } });
+		await flushPromises();
+
+		const text = wrapper.text();
+		expect(text).toContain("repo-one");
+		expect(text).toContain("First repo");
+		expect(text).toContain("TypeScript");
+		expect(wrapper.find("a").attributes("href")).toBe(
+			"https://github.com/user/repo-one",
+		);
+	});
+
+	it("renders a fallback when the fetch fails", async () => {
+		getLatestRepos.mockRejectedValue(new Error("boom"));
+		const wrapper = mount(Github, { global: { stubs } });
+		await flushPromises();
+
+		expect(wrapper.text()).toContain("Progetti non disponibili");
+	});
+});

--- a/app/components/__tests__/Watching.server.test.ts
+++ b/app/components/__tests__/Watching.server.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+const { watching } = vi.hoisted(() => ({
+	watching: {
+		series: { label: "A Series", imdb: "https://www.imdb.com/title/series" },
+		movie: { label: "A Movie", imdb: "https://www.imdb.com/title/movie" },
+	} as {
+		series?: { label: string; imdb: string };
+		movie?: { label: string; imdb: string };
+	},
+}));
+
+vi.mock("@/utils/now", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/utils/now")>();
+	return {
+		...actual,
+		get NOW_WATCHING() {
+			return watching;
+		},
+	};
+});
+
+import Watching from "../now/Watching.server.vue";
+
+const stubs = {
+	NuxtLink: {
+		template: '<a :href="href"><slot /></a>',
+		props: ["href"],
+	},
+	IconsExternal: true,
+};
+
+describe("now/Watching", () => {
+	it("renders correctly", () => {
+		watching.series = {
+			label: "A Series",
+			imdb: "https://www.imdb.com/title/series",
+		};
+		watching.movie = {
+			label: "A Movie",
+			imdb: "https://www.imdb.com/title/movie",
+		};
+		const wrapper = mount(Watching, { global: { stubs } });
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it("links the series and movie to their IMDB pages", () => {
+		watching.series = {
+			label: "A Series",
+			imdb: "https://www.imdb.com/title/series",
+		};
+		watching.movie = {
+			label: "A Movie",
+			imdb: "https://www.imdb.com/title/movie",
+		};
+		const wrapper = mount(Watching, { global: { stubs } });
+		const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+		expect(hrefs).toEqual([
+			"https://www.imdb.com/title/series",
+			"https://www.imdb.com/title/movie",
+		]);
+		expect(wrapper.text()).toContain("A Series");
+		expect(wrapper.text()).toContain("A Movie");
+	});
+
+	it("renders only the entries whose data node exists", () => {
+		watching.series = {
+			label: "A Series",
+			imdb: "https://www.imdb.com/title/series",
+		};
+		watching.movie = undefined;
+		const wrapper = mount(Watching, { global: { stubs } });
+
+		const items = wrapper.findAll("li");
+		expect(items).toHaveLength(1);
+		expect(wrapper.text()).toContain("Serie TV");
+		expect(wrapper.text()).not.toContain("Film");
+	});
+
+	it("renders no entries when no data node exists", () => {
+		watching.series = undefined;
+		watching.movie = undefined;
+		const wrapper = mount(Watching, { global: { stubs } });
+
+		expect(wrapper.findAll("li")).toHaveLength(0);
+	});
+});

--- a/app/components/__tests__/Weather.test.ts
+++ b/app/components/__tests__/Weather.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const { getWeather } = vi.hoisted(() => ({ getWeather: vi.fn() }));
+
+vi.mock("@/utils/now", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/utils/now")>();
+	return { ...actual, getWeather };
+});
+
+import Weather from "../now/Weather.vue";
+
+describe("now/Weather", () => {
+	beforeEach(() => {
+		getWeather.mockReset();
+	});
+
+	it("shows a loading state before the data resolves", () => {
+		getWeather.mockReturnValue(new Promise(() => {}));
+		const wrapper = mount(Weather);
+		expect(wrapper.text()).toContain("Caricamento");
+	});
+
+	it("renders the temperature and condition on success", async () => {
+		getWeather.mockResolvedValue({
+			city: "Milano",
+			temperature: 22,
+			emoji: "☀️",
+			label: "Sereno",
+		});
+		const wrapper = mount(Weather);
+		await flushPromises();
+
+		const text = wrapper.text();
+		expect(text).toContain("22°C");
+		expect(text).toContain("Sereno");
+		expect(text).toContain("Milano");
+	});
+
+	it("renders a fallback when the fetch fails", async () => {
+		getWeather.mockRejectedValue(new Error("boom"));
+		const wrapper = mount(Weather);
+		await flushPromises();
+
+		expect(wrapper.text()).toContain("Meteo non disponibile");
+	});
+});

--- a/app/components/__tests__/Work.server.test.ts
+++ b/app/components/__tests__/Work.server.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+const { work } = vi.hoisted(() => ({
+	work: { company: "Acme Inc", role: "Engineer", city: "Milano" },
+}));
+
+vi.mock("@/utils/now", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/utils/now")>();
+	return {
+		...actual,
+		get NOW_WORK() {
+			return work;
+		},
+	};
+});
+
+import Work from "../now/Work.server.vue";
+
+describe("now/Work", () => {
+	it("renders correctly", () => {
+		const wrapper = mount(Work);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it("renders the configured role, company and city", () => {
+		const wrapper = mount(Work);
+		const text = wrapper.text();
+		expect(text).toContain(work.role);
+		expect(text).toContain(work.company);
+		expect(text).toContain(work.city);
+	});
+});

--- a/app/components/__tests__/__snapshots__/Event.server.test.ts.snap
+++ b/app/components/__tests__/__snapshots__/Event.server.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`now/Event > renders correctly 1`] = `
+"<article class="now-card now-event">
+  <p class="now-card-kicker">Prossimo evento</p>
+  <h2><a href="https://example.com/event" target="_blank" rel="noopener">An Event <icons-external-stub lazy="false"></icons-external-stub></a></h2>
+  <p class="now-event-date"><span aria-label="calendario" role="img">📅</span> next month</p>
+</article>"
+`;

--- a/app/components/__tests__/__snapshots__/Header.test.ts.snap
+++ b/app/components/__tests__/__snapshots__/Header.test.ts.snap
@@ -7,7 +7,8 @@ exports[`Header > renders correctly 1`] = `
     <nav>
       <nuxt-link-stub href="/post/page/1" target="_self" title="Tutti gli articoli del blog" class="navitem"></nuxt-link-stub>
       <nuxt-link-stub href="/about" target="_self" title="Qualche riga su di me" class="navitem"></nuxt-link-stub>
-      <nuxt-link-stub href="/tags" target="_self" title="Articoli per tag" class="navitem"></nuxt-link-stub><a class="navitem" aria-label="theme switcher" href="#" id="theme"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+      <nuxt-link-stub href="/tags" target="_self" title="Articoli per tag" class="navitem"></nuxt-link-stub>
+      <nuxt-link-stub href="/now" target="_self" title="Cosa sto facendo in questo periodo" class="navitem"></nuxt-link-stub><a class="navitem" aria-label="theme switcher" href="#" id="theme"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor">
           <path class="moon" d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
         </svg></a>
     </nav>
@@ -22,7 +23,8 @@ exports[`Header > renders site logo with correct attributes 1`] = `
     <nav>
       <nuxt-link-stub href="/post/page/1" target="_self" title="Tutti gli articoli del blog" class="navitem"></nuxt-link-stub>
       <nuxt-link-stub href="/about" target="_self" title="Qualche riga su di me" class="navitem"></nuxt-link-stub>
-      <nuxt-link-stub href="/tags" target="_self" title="Articoli per tag" class="navitem"></nuxt-link-stub><a class="navitem" aria-label="theme switcher" href="#" id="theme"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+      <nuxt-link-stub href="/tags" target="_self" title="Articoli per tag" class="navitem"></nuxt-link-stub>
+      <nuxt-link-stub href="/now" target="_self" title="Cosa sto facendo in questo periodo" class="navitem"></nuxt-link-stub><a class="navitem" aria-label="theme switcher" href="#" id="theme"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor">
           <path class="moon" d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
         </svg></a>
     </nav>

--- a/app/components/__tests__/__snapshots__/Watching.server.test.ts.snap
+++ b/app/components/__tests__/__snapshots__/Watching.server.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`now/Watching > renders correctly 1`] = `
+"<article class="now-card now-watching">
+  <p class="now-card-kicker">Cosa sto guardando</p>
+  <ul>
+    <li><span class="now-watching-type">Serie TV</span><a href="https://www.imdb.com/title/series" target="_blank" rel="noopener">A Series <icons-external-stub lazy="false"></icons-external-stub></a></li>
+    <li><span class="now-watching-type">Film</span><a href="https://www.imdb.com/title/movie" target="_blank" rel="noopener">A Movie <icons-external-stub lazy="false"></icons-external-stub></a></li>
+  </ul>
+</article>"
+`;

--- a/app/components/__tests__/__snapshots__/Work.server.test.ts.snap
+++ b/app/components/__tests__/__snapshots__/Work.server.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`now/Work > renders correctly 1`] = `
+"<article class="now-card now-work">
+  <p class="now-card-kicker">Al lavoro</p>
+  <h2>Engineer</h2>
+  <p class="now-work-company">Acme Inc</p>
+  <p class="now-work-city"><span aria-label="luogo" role="img">📍</span> Milano</p>
+</article>"
+`;

--- a/app/components/now/Event.css
+++ b/app/components/now/Event.css
@@ -1,0 +1,16 @@
+article.now-event > h2 {
+	margin: 0;
+	font-size: 1.5rem;
+	line-height: 1.2;
+}
+
+article.now-event > h2 a {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--sp-1);
+}
+
+article.now-event .now-event-date {
+	margin: 0;
+	color: var(--text-secodary-content);
+}

--- a/app/components/now/Event.server.vue
+++ b/app/components/now/Event.server.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { NOW_EVENT } from "@/utils/now";
+</script>
+
+<template>
+  <article class="now-card now-event">
+    <p class="now-card-kicker">Prossimo evento</p>
+    <h2>
+      <NuxtLink :href="NOW_EVENT.url" target="_blank" rel="noopener">
+        {{ NOW_EVENT.name }}
+        <IconsExternal />
+      </NuxtLink>
+    </h2>
+    <p v-if="NOW_EVENT.date" class="now-event-date">
+      <span aria-label="calendario" role="img">📅</span> {{ NOW_EVENT.date }}
+    </p>
+  </article>
+</template>
+
+<style>
+@import './card.css';
+</style>
+
+<style>
+@import './Event.css';
+</style>

--- a/app/components/now/Github.css
+++ b/app/components/now/Github.css
@@ -1,0 +1,40 @@
+article.now-github .now-github-state {
+	margin: 0;
+	color: var(--text-secodary-content);
+}
+
+article.now-github > ul {
+	display: flex;
+	flex-direction: column;
+	gap: var(--sp-2);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+article.now-github li {
+	display: flex;
+	flex-direction: column;
+	gap: var(--sp-05);
+	padding-bottom: var(--sp-2);
+	border-bottom: 1px solid var(--border);
+}
+
+article.now-github li:last-child {
+	padding-bottom: 0;
+	border-bottom: none;
+}
+
+article.now-github li > a {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--sp-05);
+	font-size: 1.1rem;
+	font-weight: 600;
+}
+
+article.now-github .now-github-desc {
+	margin: 0;
+	font-size: 0.9rem;
+	color: var(--text-secodary-content);
+}

--- a/app/components/now/Github.vue
+++ b/app/components/now/Github.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { getLatestRepos, NOW_GITHUB_USER, type Repo } from "@/utils/now";
+
+const loading = ref(true);
+const error = ref(false);
+const repos = ref<Repo[]>([]);
+
+onMounted(async () => {
+  try {
+    repos.value = await getLatestRepos(NOW_GITHUB_USER, 3);
+  } catch {
+    error.value = true;
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <article class="now-card now-github">
+    <p class="now-card-kicker">Ultimi progetti su GitHub</p>
+
+    <p v-if="loading" class="now-github-state">Caricamento…</p>
+
+    <p v-else-if="error" class="now-github-state">
+      Progetti non disponibili
+    </p>
+
+    <ul v-else>
+      <li v-for="repo in repos" :key="repo.url">
+        <NuxtLink :href="repo.url" target="_blank" rel="noopener">
+          {{ repo.name }}
+          <IconsExternal />
+        </NuxtLink>
+        <p v-if="repo.description" class="now-github-desc">
+          {{ repo.description }}
+        </p>
+        <span v-if="repo.language" class="sl-badge">{{ repo.language }}</span>
+      </li>
+    </ul>
+  </article>
+</template>
+
+<style>
+@import url('../Badge.css');
+</style>
+
+<style>
+@import './card.css';
+</style>
+
+<style>
+@import './Github.css';
+</style>

--- a/app/components/now/Watching.css
+++ b/app/components/now/Watching.css
@@ -1,0 +1,29 @@
+article.now-watching > ul {
+	display: flex;
+	flex-direction: column;
+	gap: var(--sp-2);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+article.now-watching li {
+	display: flex;
+	flex-direction: column;
+	gap: var(--sp-05);
+}
+
+article.now-watching .now-watching-type {
+	font-size: 0.75rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--text-secodary-content);
+}
+
+article.now-watching li a {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--sp-05);
+	font-size: 1.15rem;
+	font-weight: 600;
+}

--- a/app/components/now/Watching.server.vue
+++ b/app/components/now/Watching.server.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { NOW_WATCHING } from "@/utils/now";
+
+// Only render an entry when its config node is present, so the widget gracefully
+// shows just the series, just the movie, or nothing at all.
+const items = [
+  { type: "Serie TV", ...NOW_WATCHING.series },
+  { type: "Film", ...NOW_WATCHING.movie },
+].filter((item) => item.label && item.imdb);
+</script>
+
+<template>
+  <article class="now-card now-watching">
+    <p class="now-card-kicker">Cosa sto guardando</p>
+    <ul>
+      <li v-for="item in items" :key="item.type">
+        <span class="now-watching-type">{{ item.type }}</span>
+        <NuxtLink :href="item.imdb" target="_blank" rel="noopener">
+          {{ item.label }}
+          <IconsExternal />
+        </NuxtLink>
+      </li>
+    </ul>
+  </article>
+</template>
+
+<style>
+@import './card.css';
+</style>
+
+<style>
+@import './Watching.css';
+</style>

--- a/app/components/now/Weather.css
+++ b/app/components/now/Weather.css
@@ -1,0 +1,27 @@
+article.now-weather {
+	align-items: flex-start;
+}
+
+article.now-weather .now-weather-state {
+	margin: 0;
+	color: var(--text-secodary-content);
+}
+
+article.now-weather .now-weather-emoji {
+	margin: 0;
+	font-size: 3rem;
+	line-height: 1;
+}
+
+article.now-weather .now-weather-temp {
+	margin: 0;
+	font-size: 2.5rem;
+	font-weight: 700;
+	line-height: 1;
+	color: var(--text-base-content);
+}
+
+article.now-weather .now-weather-meta {
+	margin: 0;
+	color: var(--text-secodary-content);
+}

--- a/app/components/now/Weather.vue
+++ b/app/components/now/Weather.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { getWeather, NOW_WEATHER_LOCATION, type Weather } from "@/utils/now";
+
+const loading = ref(true);
+const error = ref(false);
+const data = ref<Weather | null>(null);
+
+onMounted(async () => {
+  try {
+    data.value = await getWeather(NOW_WEATHER_LOCATION);
+  } catch {
+    error.value = true;
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <article class="now-card now-weather">
+    <p class="now-card-kicker">Meteo</p>
+
+    <p v-if="loading" class="now-weather-state">Caricamento…</p>
+
+    <p v-else-if="error || !data" class="now-weather-state">
+      Meteo non disponibile
+    </p>
+
+    <template v-else>
+      <p class="now-weather-emoji" :aria-label="data.label" role="img">
+        {{ data.emoji }}
+      </p>
+      <p class="now-weather-temp">{{ data.temperature }}°C</p>
+      <p class="now-weather-meta">{{ data.label }} · {{ data.city }}</p>
+    </template>
+  </article>
+</template>
+
+<style>
+@import './card.css';
+</style>
+
+<style>
+@import './Weather.css';
+</style>

--- a/app/components/now/Work.css
+++ b/app/components/now/Work.css
@@ -1,0 +1,18 @@
+article.now-work > h2 {
+	margin: 0;
+	font-size: 1.5rem;
+	line-height: 1.2;
+	color: var(--text-base-content);
+}
+
+article.now-work .now-work-company {
+	margin: 0;
+	font-size: 1.1rem;
+	font-weight: 600;
+	color: var(--primary);
+}
+
+article.now-work .now-work-city {
+	margin: 0;
+	color: var(--text-secodary-content);
+}

--- a/app/components/now/Work.server.vue
+++ b/app/components/now/Work.server.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { NOW_WORK } from "@/utils/now";
+</script>
+
+<template>
+  <article class="now-card now-work">
+    <p class="now-card-kicker">Al lavoro</p>
+    <h2>{{ NOW_WORK.role }}</h2>
+    <p class="now-work-company">{{ NOW_WORK.company }}</p>
+    <p class="now-work-city">
+      <span aria-label="luogo" role="img">📍</span> {{ NOW_WORK.city }}
+    </p>
+  </article>
+</template>
+
+<style>
+@import './card.css';
+</style>
+
+<style>
+@import './Work.css';
+</style>

--- a/app/components/now/card.css
+++ b/app/components/now/card.css
@@ -1,0 +1,62 @@
+/*
+Shared base styling for the "Adesso" (/now) widget cards.
+Each widget imports this file plus its own sibling stylesheet.
+*/
+
+.now-card {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: var(--sp-2);
+	height: 100%;
+	padding: var(--sp-3);
+	border: 1px solid var(--border);
+	border-radius: var(--sp-05);
+	background-color: var(--bg-neutral);
+	color: var(--text-base-content);
+	transition:
+		transform 200ms ease,
+		border-color 200ms ease,
+		box-shadow 200ms ease;
+}
+
+.now-card:hover {
+	transform: translateY(-2px);
+	border-color: var(--primary);
+	box-shadow: 0 8px 20px -8px rgba(0, 0, 0, 0.25);
+}
+
+/* Editorial kicker shared by every widget header. */
+.now-card > .now-card-kicker {
+	margin: 0;
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--text-secodary-content);
+}
+
+.now-card a {
+	color: var(--primary);
+	text-decoration: none;
+	transition: color 150ms ease;
+}
+
+.now-card a:hover {
+	color: var(--header-link-hover);
+}
+
+.now-card svg {
+	display: inline-block;
+	width: 0.85rem;
+	height: 0.85rem;
+	color: var(--text-secodary-content);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.now-card,
+	.now-card:hover {
+		transform: none;
+		transition: none;
+	}
+}

--- a/app/pages/now-page.css
+++ b/app/pages/now-page.css
@@ -1,0 +1,52 @@
+section.now-page > hgroup {
+	margin-bottom: var(--sp-5);
+}
+
+section.now-page > hgroup > h1 {
+	margin: 0 0 var(--sp-1);
+}
+
+section.now-page > hgroup > p {
+	margin: 0;
+	max-width: 42rem;
+	color: var(--text-secodary-content);
+}
+
+/* Mobile first: single column, source order. */
+.now-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: var(--sp-3);
+}
+
+/* Bento layout from the md breakpoint up: a tall GitHub column on the left,
+   stacked cards on the right. */
+@media (min-width: 768px) {
+	.now-grid {
+		grid-template-columns: 1fr 1fr;
+		grid-template-areas:
+			"work    weather"
+			"github  watching"
+			"github  event";
+	}
+
+	.now-grid-work {
+		grid-area: work;
+	}
+
+	.now-grid-weather {
+		grid-area: weather;
+	}
+
+	.now-grid-github {
+		grid-area: github;
+	}
+
+	.now-grid-watching {
+		grid-area: watching;
+	}
+
+	.now-grid-event {
+		grid-area: event;
+	}
+}

--- a/app/pages/now.vue
+++ b/app/pages/now.vue
@@ -1,0 +1,49 @@
+<script lang="ts" setup>
+import { SITE_TITLE } from "@/utils/config";
+
+const title = `${SITE_TITLE} - Adesso`;
+const description =
+	"Una fotografia del presente, ma con i dati invece che con la pellicola.";
+</script>
+
+<template>
+  <section class="now-page">
+
+    <Head>
+      <Title>{{ title }}</Title>
+      <Meta name="title" :content="title" />
+      <Meta name="description" :content="description" />
+
+      <!-- Open Graph / Facebook -->
+      <Meta property="og:type" content="website" />
+      <Meta property="og:url" content="https://salvatorelaisa.blog/now" />
+      <Meta property="og:title" :content="title" />
+      <Meta property="og:description" :content="description" />
+      <Meta property="og:image" content="https://salvatorelaisa.blog/static/images/twitter-card.png" />
+
+      <!-- Twitter -->
+      <Meta property="twitter:card" content="summary_large_image" />
+      <Meta property="twitter:url" content="https://salvatorelaisa.blog/now" />
+      <Meta property="twitter:title" :content="title" />
+      <Meta property="twitter:description" :content="description" />
+      <Meta property="twitter:image" content="https://salvatorelaisa.blog/static/images/twitter-card.png" />
+    </Head>
+
+    <hgroup>
+      <h1>Adesso</h1>
+      <p>{{ description }}</p>
+    </hgroup>
+
+    <div class="now-grid">
+      <NowWork class="now-grid-work" />
+      <NowWeather class="now-grid-weather" />
+      <NowGithub class="now-grid-github" />
+      <NowWatching class="now-grid-watching" />
+      <NowEvent class="now-grid-event" />
+    </div>
+  </section>
+</template>
+
+<style>
+@import './now-page.css';
+</style>

--- a/app/utils/__tests__/now.test.ts
+++ b/app/utils/__tests__/now.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+	weatherCodeToIcon,
+	getWeather,
+	getLatestRepos,
+} from "../now";
+
+describe("weatherCodeToIcon", () => {
+	it("maps representative WMO codes to the expected Italian labels", () => {
+		expect(weatherCodeToIcon(0).label).toBe("Sereno");
+		expect(weatherCodeToIcon(2).label).toBe("Poco nuvoloso");
+		expect(weatherCodeToIcon(45).label).toBe("Nebbia");
+		expect(weatherCodeToIcon(55).label).toBe("Pioviggine");
+		expect(weatherCodeToIcon(63).label).toBe("Pioggia");
+		expect(weatherCodeToIcon(73).label).toBe("Neve");
+		expect(weatherCodeToIcon(81).label).toBe("Rovesci");
+		expect(weatherCodeToIcon(86).label).toBe("Rovesci di neve");
+		expect(weatherCodeToIcon(95).label).toBe("Temporale");
+		expect(weatherCodeToIcon(99).label).toBe("Temporale con grandine");
+	});
+
+	it("returns each mapping with a non-empty emoji", () => {
+		expect(weatherCodeToIcon(0).emoji).not.toBe("");
+	});
+
+	it("falls back to a default for unknown codes", () => {
+		const unknown = weatherCodeToIcon(1234);
+		expect(unknown.emoji).toBe("❓");
+		expect(unknown.label).toBe("Non disponibile");
+	});
+});
+
+describe("getWeather", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("resolves a city to its rounded temperature and condition", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				results: [{ name: "Milano", latitude: 45.46, longitude: 9.18 }],
+			})
+			.mockResolvedValueOnce({
+				current: { temperature_2m: 21.6, weather_code: 0 },
+			});
+		vi.stubGlobal("$fetch", fetchMock);
+
+		const weather = await getWeather("Milano");
+
+		expect(weather).toEqual({
+			city: "Milano",
+			temperature: 22,
+			emoji: "☀️",
+			label: "Sereno",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws when the location cannot be geocoded", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce({ results: [] });
+		vi.stubGlobal("$fetch", fetchMock);
+
+		await expect(getWeather("Nowhere")).rejects.toThrow("Località non trovata");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("getLatestRepos", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("maps the GitHub API response and honors the count", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce([
+			{
+				name: "repo-one",
+				html_url: "https://github.com/user/repo-one",
+				description: "First repo",
+				language: "TypeScript",
+				updated_at: "2026-06-01T00:00:00Z",
+			},
+		]);
+		vi.stubGlobal("$fetch", fetchMock);
+
+		const repos = await getLatestRepos("user", 3);
+
+		expect(repos).toEqual([
+			{
+				name: "repo-one",
+				url: "https://github.com/user/repo-one",
+				description: "First repo",
+				language: "TypeScript",
+				updatedAt: "2026-06-01T00:00:00Z",
+			},
+		]);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.github.com/users/user/repos",
+			{ query: { sort: "updated", per_page: 3 } },
+		);
+	});
+});

--- a/app/utils/now.ts
+++ b/app/utils/now.ts
@@ -1,0 +1,140 @@
+// Data + config for the "Adesso" (/now) page.
+//
+// The constants below are editable placeholders: tweak them to reflect what you
+// are currently doing. The async helpers fetch live data client-side (no API
+// key required) and are unit-tested with `$fetch` stubbed.
+
+// --- editable placeholders ----------------------------------------------------
+
+export const NOW_WORK = {
+	company: "Carol Health",
+	role: "Engineering Tech Lead",
+	city: "Milano",
+};
+
+// City queried for the weather widget.
+export const NOW_WEATHER_LOCATION = "Milano";
+
+export const NOW_GITHUB_USER = "moebiusmania";
+
+export const NOW_WATCHING = {
+	series: { label: "Spider Noir", imdb: "https://www.imdb.com/title/tt30460310/" },
+	// movie: { label: "TODO", imdb: "https://www.imdb.com/title/TODO" },
+};
+
+export const NOW_EVENT = {
+	name: "Festa del Ticino - Pavia",
+	url: "https://www.visitpavia.com/en/event/festa-del-ticino-pavia",
+	date: "primi di Settembre",
+};
+
+// --- weather ------------------------------------------------------------------
+
+export type WeatherIcon = { emoji: string; label: string };
+
+// Maps a WMO weather interpretation code to an emoji + Italian label.
+// Reference: https://open-meteo.com/en/docs (WMO Weather interpretation codes).
+export const weatherCodeToIcon = (code: number): WeatherIcon => {
+	if (code === 0) return { emoji: "☀️", label: "Sereno" };
+	if (code >= 1 && code <= 3) return { emoji: "⛅", label: "Poco nuvoloso" };
+	if (code === 45 || code === 48) return { emoji: "🌫️", label: "Nebbia" };
+	if (code >= 51 && code <= 57) return { emoji: "🌦️", label: "Pioviggine" };
+	if (code >= 61 && code <= 67) return { emoji: "🌧️", label: "Pioggia" };
+	if (code >= 71 && code <= 77) return { emoji: "🌨️", label: "Neve" };
+	if (code >= 80 && code <= 82) return { emoji: "🌧️", label: "Rovesci" };
+	if (code === 85 || code === 86)
+		return { emoji: "🌨️", label: "Rovesci di neve" };
+	if (code === 95) return { emoji: "⛈️", label: "Temporale" };
+	if (code === 96 || code === 99)
+		return { emoji: "⛈️", label: "Temporale con grandine" };
+	return { emoji: "❓", label: "Non disponibile" };
+};
+
+export type Weather = {
+	city: string;
+	temperature: number;
+	emoji: string;
+	label: string;
+};
+
+type GeocodingResponse = {
+	results?: Array<{ name: string; latitude: number; longitude: number }>;
+};
+
+type ForecastResponse = {
+	current?: { temperature_2m: number; weather_code: number };
+};
+
+// Resolves a city name to its current temperature + weather condition using the
+// free Open-Meteo geocoding + forecast APIs (no API key, CORS-friendly).
+export const getWeather = async (location: string): Promise<Weather> => {
+	const geo = await $fetch<GeocodingResponse>(
+		"https://geocoding-api.open-meteo.com/v1/search",
+		{ query: { name: location, count: 1, language: "it", format: "json" } },
+	);
+
+	const place = geo.results?.[0];
+	if (!place) {
+		throw new Error(`Località non trovata: ${location}`);
+	}
+
+	const forecast = await $fetch<ForecastResponse>(
+		"https://api.open-meteo.com/v1/forecast",
+		{
+			query: {
+				latitude: place.latitude,
+				longitude: place.longitude,
+				current: "temperature_2m,weather_code",
+			},
+		},
+	);
+
+	const current = forecast.current;
+	if (!current) {
+		throw new Error(`Meteo non disponibile per: ${location}`);
+	}
+
+	return {
+		city: place.name,
+		temperature: Math.round(current.temperature_2m),
+		...weatherCodeToIcon(current.weather_code),
+	};
+};
+
+// --- github -------------------------------------------------------------------
+
+export type Repo = {
+	name: string;
+	url: string;
+	description: string | null;
+	language: string | null;
+	updatedAt: string;
+};
+
+type GithubRepo = {
+	name: string;
+	html_url: string;
+	description: string | null;
+	language: string | null;
+	updated_at: string;
+};
+
+// Fetches a user's most recently updated public repositories via the GitHub API.
+// Unauthenticated requests are rate-limited to 60/hour per IP (fine for a blog).
+export const getLatestRepos = async (
+	user: string,
+	count = 3,
+): Promise<Repo[]> => {
+	const repos = await $fetch<GithubRepo[]>(
+		`https://api.github.com/users/${user}/repos`,
+		{ query: { sort: "updated", per_page: count } },
+	);
+
+	return repos.map((repo) => ({
+		name: repo.name,
+		url: repo.html_url,
+		description: repo.description,
+		language: repo.language,
+		updatedAt: repo.updated_at,
+	}));
+};

--- a/deno.lock
+++ b/deno.lock
@@ -6853,7 +6853,6 @@
         "npm:@nuxt/content@3.14.0",
         "npm:@nuxt/image@2.0.0",
         "npm:@nuxt/test-utils@4.0.3",
-        "npm:@nuxtjs/sitemap@8.2.1",
         "npm:@vue/test-utils@2.4.11",
         "npm:better-sqlite3@12.11.1",
         "npm:happy-dom@20.10.6",


### PR DESCRIPTION
# Nuova pagina "Adesso" (`/now`)

Aggiunge una pagina `/now` — etichettata **"Adesso"** nel titolo e nella navigazione —
che raccoglie una serie di "widget" su cosa sto facendo in questo periodo.

## Cosa include

- **Al lavoro**: azienda, ruolo e città (statico, da configurazione).
- **Meteo**: temperatura attuale e condizione (emoji + etichetta) per una città,
  via [Open-Meteo](https://open-meteo.com) (geocoding + forecast, senza API key).
- **Ultimi progetti su GitHub**: i 3 repository aggiornati più di recente dal mio
  profilo, via API pubblica di GitHub.
- **Cosa sto guardando**: serie TV e/o film con link a IMDB. Ogni voce viene
  mostrata solo se il relativo dato è presente.
- **Prossimo evento**: nome, data e link dell'evento che ho intenzione di visitare.

## Dettagli tecnici

- **Fetch lato client** per meteo e GitHub: dati sempre aggiornati, con stati di
  caricamento ed errore. Il sito resta completamente statico (`npm run generate`).
- **Contenuti statici** (lavoro, cosa guardo, evento) configurabili in
  [`app/utils/now.ts`](app/utils/now.ts).
- Widget come componenti dedicati in [`app/components/now/`](app/components/now/),
  ognuno con il proprio file `.css` (convenzione del progetto) e una base condivisa
  in `card.css`.
- **Layout a griglia "bento"** responsive: colonna singola su mobile, griglia su
  schermi ≥ 768px.
- Meta SEO (`<Head>`) dedicati per la rotta, voce "Adesso" aggiunta alla
  navigazione nell'header.

## Test

- Test unitari per gli helper (`weatherCodeToIcon`, `getWeather`, `getLatestRepos`)
  con `$fetch` mockato.
- Test dei componenti: rendering dei widget statici, stati di caricamento/successo/
  errore dei widget dinamici e rendering condizionale di "Cosa sto guardando".
- I test dei widget statici usano valori di configurazione mockati, così le modifiche
  ai contenuti reali non rompono la suite.
- Suite completa verde (94 test) e build `npm run generate` che emette la rotta `/now`.
