### PR TITLE
Set summer theme and move /now weather location to Edinburgh

### DIFF
--- a/app/components/__tests__/__snapshots__/Footer.test.ts.snap
+++ b/app/components/__tests__/__snapshots__/Footer.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Footer > renders correctly 1`] = `
 >
   <div>
     <span>
-      Salvatore Laisa Blog 
+      Salvatore Laisa Blog 🌤️🏖️
     </span>
     <p>
        © 2010 - 2026 — sviluppato con 

--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -4,7 +4,7 @@ export type Theme = "default" | "halloween" | "spring" | "summer" | "xmas";
 
 export const SITE_TITLE = "Salvatore Laisa";
 export const SITE_DESCRIPTION = "Blog personale.";
-export const CURRENT_THEME: Theme = "default";
+export const CURRENT_THEME: Theme = "summer";
 export const EVENTS = {
 	xmas: {
 		name: "🎁",

--- a/app/utils/now.ts
+++ b/app/utils/now.ts
@@ -9,11 +9,11 @@
 export const NOW_WORK = {
 	company: "Carol Health",
 	role: "Engineering Tech Lead",
-	city: "Milano",
+	city: "Edimburgo",
 };
 
 // City queried for the weather widget.
-export const NOW_WEATHER_LOCATION = "Milano";
+export const NOW_WEATHER_LOCATION = "Edinburgh";
 
 export const NOW_GITHUB_USER = "moebiusmania";
 

--- a/app/utils/now.ts
+++ b/app/utils/now.ts
@@ -9,7 +9,7 @@
 export const NOW_WORK = {
 	company: "Carol Health",
 	role: "Engineering Tech Lead",
-	city: "Edimburgo",
+	city: "Milano",
 };
 
 // City queried for the weather widget.


### PR DESCRIPTION
## Summary

- Enable the **summer theme** (`CURRENT_THEME = "summer"` in `app/utils/config.ts`), which also surfaces the `🌤️🏖️` season emoji.
- Update the **/now weather widget** location to Edinburgh (`NOW_WEATHER_LOCATION = "Edinburgh"` in `app/utils/now.ts`). The work city stays **Milano**.
- Refresh the `Footer` snapshot to account for the summer season emoji.

## Testing

- `npm test` → 27 files / 94 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ba2Xmgy4NF9rMv24NG3Jbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ba2Xmgy4NF9rMv24NG3Jbq)_